### PR TITLE
Codelab datastore

### DIFF
--- a/codelab-android-datastore-master/app/build.gradle
+++ b/codelab-android-datastore-master/app/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$supportLibVersion"
     implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
     implementation "com.google.android.material:material:$materialVersion"
+    implementation "androidx.datastore:datastore-preferences:1.0.0"
 
     // kotlin
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"

--- a/codelab-android-datastore-master/app/src/main/java/com/codelab/android/datastore/data/UserPreferencesRepository.kt
+++ b/codelab-android-datastore-master/app/src/main/java/com/codelab/android/datastore/data/UserPreferencesRepository.kt
@@ -18,6 +18,8 @@ package com.codelab.android.datastore.data
 
 import android.content.Context
 import androidx.core.content.edit
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -31,10 +33,12 @@ enum class SortOrder {
     BY_DEADLINE_AND_PRIORITY
 }
 
+data class UserPreferences(val showCompleted: Boolean)
+
 /**
  * Class that handles saving and retrieving user preferences
  */
-class UserPreferencesRepository private constructor(context: Context) {
+class UserPreferencesRepository constructor(private val dataStore: DataStore<Preferences>, context: Context) {
 
     private val sharedPreferences =
         context.applicationContext.getSharedPreferences(USER_PREFERENCES_NAME, Context.MODE_PRIVATE)
@@ -95,23 +99,6 @@ class UserPreferencesRepository private constructor(context: Context) {
     private fun updateSortOrder(sortOrder: SortOrder) {
         sharedPreferences.edit {
             putString(SORT_ORDER_KEY, sortOrder.name)
-        }
-    }
-
-    companion object {
-        @Volatile
-        private var INSTANCE: UserPreferencesRepository? = null
-
-        fun getInstance(context: Context): UserPreferencesRepository {
-            return INSTANCE ?: synchronized(this) {
-                INSTANCE?.let {
-                    return it
-                }
-
-                val instance = UserPreferencesRepository(context)
-                INSTANCE = instance
-                instance
-            }
         }
     }
 }

--- a/codelab-android-datastore-master/app/src/main/java/com/codelab/android/datastore/ui/TasksActivity.kt
+++ b/codelab-android-datastore-master/app/src/main/java/com/codelab/android/datastore/ui/TasksActivity.kt
@@ -16,14 +16,22 @@
 
 package com.codelab.android.datastore.ui
 
+import android.content.Context
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.datastore.preferences.preferencesDataStore
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.DividerItemDecoration
 import com.codelab.android.datastore.data.SortOrder
 import com.codelab.android.datastore.data.TasksRepository
 import com.codelab.android.datastore.data.UserPreferencesRepository
 import com.codelab.android.datastore.databinding.ActivityTasksBinding
+
+private const val USER_PREFERENCES_NAME = "user_preferences"
+
+private val Context.dataStore by preferencesDataStore(
+    name = USER_PREFERENCES_NAME
+)
 
 class TasksActivity : AppCompatActivity() {
 
@@ -40,8 +48,11 @@ class TasksActivity : AppCompatActivity() {
 
         viewModel = ViewModelProvider(
             this,
-            TasksViewModelFactory(TasksRepository, UserPreferencesRepository.getInstance(this))
-        )[TasksViewModel::class.java]
+            TasksViewModelFactory(
+                TasksRepository,
+                UserPreferencesRepository(dataStore, this)
+            )
+        ).get(TasksViewModel::class.java)
 
         setupRecyclerView()
         setupFilterListeners(viewModel)
@@ -83,4 +94,5 @@ class TasksActivity : AppCompatActivity() {
         binding.sortPriority.isChecked =
             sortOrder == SortOrder.BY_PRIORITY || sortOrder == SortOrder.BY_DEADLINE_AND_PRIORITY
     }
+
 }


### PR DESCRIPTION
## Codelab Progress Tracking Pull Request

### Tasks checklist
- [ x ] Introduction
- [ x ] Set up
- [ x ] Project overview
- [ x ] DataStore - the basics
- [ x ] Preferences DataStore overview
- [ x ] Persisting data in Preferences DataStore
- [ x ] SharedPreferences to Preferences DataStore
- [ x ] Update TasksViewModel to use UserPreferencesRepository

### Codelab Discussion


IF an android codelab:
This code lab showed me how to use a Preferences DataStore to asynchronously store small datasets in Jetpack Compose. I could use this in my project for saving app settings like dark mode/light mode.
